### PR TITLE
Fix: Define Theme Type as Dark

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) [year] [fullname]
+Copyright (c) [2024] [Daniel Yuschick]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "yuschick",
   "displayName": "Candý Pine",
   "description": "Candý Pine is a soft, harmonious and candy-inspired dark theme, based off of the beautiful Rosé Pine.",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "engines": {
     "vscode": "^1.57.0"
   },

--- a/themes/candy-pine-color-theme--italics.json
+++ b/themes/candy-pine-color-theme--italics.json
@@ -1,5 +1,6 @@
 {
   "name": "Candy Pine",
+  "type": "dark",
   "colors": {
     "activityBar.activeBorder": "#e4e1f0",
     "activityBar.background": "#161421",

--- a/themes/candy-pine-color-theme.json
+++ b/themes/candy-pine-color-theme.json
@@ -1,5 +1,6 @@
 {
   "name": "Candy Pine",
+  "type": "dark",
   "colors": {
     "activityBar.activeBorder": "#e4e1f0",
     "activityBar.background": "#161421",


### PR DESCRIPTION
## 📖 What?

- increments package version to 0.2.4
- adds theme type dark to the theme files
- updates license file

## 🤔 Why?

- missed

## 🤖 Testing

- run theme locally

